### PR TITLE
增加两种新的推送方式，修复Server Chan超出HTTPS配额导致无法推送并报错的问题

### DIFF
--- a/index.py
+++ b/index.py
@@ -101,10 +101,10 @@ class Task(object):
     '''
     def wxpusher(self):
         if (self.appToken == '' or self.wxpusheruid == ''):
-            logger.info('未填写WxPusher推送所需参数，请检查')
+            self.log('未填写WxPusher推送所需参数，请检查')
             return
         self.diyText() # 构造发送内容
-        url = 'http://wxpusher.zjiecode.com/api/send/message/'
+        url = 'https://wxpusher.zjiecode.com/api/send/message/'
         data = json.dumps({
             "appToken":self.appToken,
             "content":self.content,
@@ -113,8 +113,7 @@ class Task(object):
             "uids":[self.wxpusheruid]
         })
         response = requests.post(url, data = data, headers = {'Content-Type': 'application/json;charset=UTF-8'})
-        r=response.json()
-        if r['data'][0]['status'] == '创建发送任务成功':
+        if (response.json()['data'][0]['status']) == '创建发送任务成功':
             self.log('用户:' + self.name + '  WxPusher推送成功')
         else:
             self.log('用户:' + self.name + '  WxPusher推送失败,请检查appToken和uid是否正确')
@@ -132,11 +131,20 @@ class Task(object):
     def server(self):
         if self.sckey == '':
             return
-        url = 'https://sc.ftqq.com/' + self.sckey + '.send'
         self.diyText() # 构造发送内容
-        response = requests.get(url,params={"text":self.title, "desp":self.content})
-        data = json.loads(response.text)
-        if data['errno'] == 0:
+        data = {
+            "text":self.title,
+            "desp":self.content
+        }
+        if (self.pushmethod.lower() == 'scturbo'):      #Server酱 Turbo版
+            url = 'https://sctapi.ftqq.com/' + self.sckey + '.send'
+            response = requests.post(url, data=data, headers = {'Content-type': 'application/x-www-form-urlencoded'})
+            errno = response.json()['data']['errno']
+        else:                                           #Server酱 普通版
+            url = 'https://sc.ftqq.com/' + self.sckey + '.send'
+            response = requests.post(url, data=data, headers = {'Content-type': 'application/x-www-form-urlencoded'})
+            errno = response.json()['errno']
+        if errno == 0:
             self.log('用户:' + self.name + '  Server酱推送成功')
         else:
             self.log('用户:' + self.name + '  Server酱推送失败,请检查sckey是否正确')
@@ -219,7 +227,7 @@ class Task(object):
                 self.day = math.ceil((20000 - self.listenSongs)/300)
             self.list.append("- 打卡结束，消息推送\n\n")
             self.dakaSongs_list = ''.join(self.list)
-            if self.pushmethod == 'wxpusher':
+            if self.pushmethod.lower() == 'wxpusher':
                 self.wxpusher()
             else:
                 self.server()

--- a/index.py
+++ b/index.py
@@ -26,12 +26,14 @@ class Task(object):
     '''
     对象的构造函数
     '''
-    def __init__(self, uin, pwd, sckey, countrycode=86):
+    def __init__(self, uin, pwd, pushmethod, sckey, appToken, wxpusheruid, countrycode=86):
         self.uin = uin
         self.pwd = pwd
         self.countrycode = countrycode
+        self.pushmethod = pushmethod
         self.sckey = sckey
-
+        self.appToken = appToken
+        self.wxpusheruid = wxpusheruid
     '''
     带上用户的cookie去发送数据
     url:完整的URL路径
@@ -95,6 +97,36 @@ class Task(object):
         self.log('获取用户详情成功')
 
     '''
+    Wxpusher推送
+    '''
+    def wxpusher(self):
+        if (self.appToken == '' or self.wxpusheruid == ''):
+            logger.info('未填写WxPusher推送所需参数，请检查')
+            return
+        self.diyText() # 构造发送内容
+        url = 'http://wxpusher.zjiecode.com/api/send/message/'
+        data = json.dumps({
+            "appToken":self.appToken,
+            "content":self.content,
+            "summary":self.title,
+            "contentType":3,
+            "uids":[self.wxpusheruid]
+        })
+        response = requests.post(url, data = data, headers = {'Content-Type': 'application/json;charset=UTF-8'})
+        r=response.json()
+        if r['data'][0]['status'] == '创建发送任务成功':
+            self.log('用户:' + self.name + '  WxPusher推送成功')
+        else:
+            self.log('用户:' + self.name + '  WxPusher推送失败,请检查appToken和uid是否正确')
+
+    '''
+    自定义要推送到微信的内容
+    title:消息的标题
+    content:消息的内容,支持MarkDown格式
+    contentType:消息类型,1为普通文本,2为html,3为markdown
+    '''
+
+    '''
     Server推送
     '''
     def server(self):
@@ -114,6 +146,7 @@ class Task(object):
     title:消息的标题
     content:消息的内容,支持MarkDown格式
     '''
+
     def diyText(self):
         # today = datetime.date.today()
         # kaoyan_day = datetime.date(2020,12,21) #2021考研党的末日
@@ -186,7 +219,10 @@ class Task(object):
                 self.day = math.ceil((20000 - self.listenSongs)/300)
             self.list.append("- 打卡结束，消息推送\n\n")
             self.dakaSongs_list = ''.join(self.list)
-            self.server()
+            if self.pushmethod == 'wxpusher':
+                self.wxpusher()
+            else:
+                self.server()
         except:
             self.log('用户任务执行中断,请检查账号密码是否正确')
         else:
@@ -207,7 +243,10 @@ def init():
     api = config['setting']['api']
     md5Switch = config.getboolean('setting','md5Switch')
     peopleSwitch = config.getboolean('setting','peopleSwitch')
+    pushmethod = config['setting']['pushmethod']
     sckey = config['setting']['sckey']
+    appToken = config['setting']['appToken']
+    wxpusheruid = config['setting']['wxpusheruid']
     logger.info('配置文件读取完毕')
     conf = {
             'uin': uin,
@@ -216,7 +255,10 @@ def init():
             'api': api,
             'md5Switch': md5Switch, 
             'peopleSwitch':peopleSwitch,
-            'sckey':sckey
+            'pushmethod':pushmethod,
+            'sckey':sckey,
+            'appToken':appToken,
+            'wxpusheruid':wxpusheruid
         }
     return conf
 
@@ -262,7 +304,7 @@ def taskPool():
         account = loadJson("account.json")
         for man in account:
             logger.info('账号: ' + man['account'] + '  开始执行\n========================================')
-            task = Task(man['account'], man['password'], man['sckey'])
+            task = Task(man['account'], man['password'], man['pushmethod'],man['sckey'], man['appToken'], man['wxpusheruid'])
             task.start()
             time.sleep(10)
         logger.info('所有账号已全部完成任务,服务进入休眠中,等待明天重新启动')
@@ -271,7 +313,7 @@ def taskPool():
         if config['md5Switch'] is True:
             logger.info('MD5开关已打开,即将开始为你加密,密码不会上传至服务器,请知悉')
             config['pwd'] = md5(config['pwd'])
-        task = Task(config['uin'], config['pwd'], config['sckey'], config['countrycode'])
+        task = Task(config['uin'], config['pwd'], config['pushmethod'], config['sckey'], config['appToken'], config['wxpusheruid'], config['countrycode'])
         task.start()
 
 '''

--- a/index.py
+++ b/index.py
@@ -141,7 +141,7 @@ class Task(object):
             response = requests.post(url, data=data, headers = {'Content-type': 'application/x-www-form-urlencoded'})
             errno = response.json()['data']['errno']
         else:                                           #Server酱 普通版
-            url = 'https://sc.ftqq.com/' + self.sckey + '.send'
+            url = 'http://sc.ftqq.com/' + self.sckey + '.send'
             response = requests.post(url, data=data, headers = {'Content-type': 'application/x-www-form-urlencoded'})
             errno = response.json()['errno']
         if errno == 0:

--- a/init.config
+++ b/init.config
@@ -28,5 +28,14 @@ md5Switch = false
 # 介于账号安全着想,account.json中的密码必须填写md5加密过的,请不要向他人透露自己的明文密码
 peopleSwitch = false
 
+# 推送方式选择
+# 使用 Wxpusher 推送请填写 wxpusher，使用 Server 酱推送或不推送请留空。
+# 例如：pushmethod = wxpusher
+pushmethod =
+
 # Server酱的密匙,不需要推送就留空,密匙的免费申请参考:http://sc.ftqq.com/
 sckey = SCU97783T70c13167b4daa422f4d419a765eb4ebb5ebc9********
+
+# Wxpusher 推送参数，需要将pushmethod指定为wxpusher，应用和uid的免费申请参考:https://wxpusher.zjiecode.com/
+appToken = AT_6kBmt***************************
+wxpusheruid = UID_t***************************

--- a/init.config
+++ b/init.config
@@ -29,11 +29,16 @@ md5Switch = false
 peopleSwitch = false
 
 # 推送方式选择
-# 使用 Wxpusher 推送请填写 wxpusher，使用 Server 酱推送或不推送请留空。
-# 例如：pushmethod = wxpusher
+# 可选参数wxpusher、SCTurbo或留空
+# wxpusher: 使用 WxPusher 推送
+# SCTurbo: 使用 Server酱Turbo版 推送
+# 留空：使用 Server酱免费版 推送或不推送
 pushmethod =
 
-# Server酱的密匙,不需要推送就留空,密匙的免费申请参考:http://sc.ftqq.com/
+# Server酱的密匙,不需要推送就留空
+# 免费版密匙的免费申请参考:http://sc.ftqq.com/
+# Turbo版的密钥获取:https://sct.ftqq.com/sendkey
+# 免费版和Turbo版的密钥长度不一样，请注意检查，不可混用
 sckey = SCU97783T70c13167b4daa422f4d419a765eb4ebb5ebc9********
 
 # Wxpusher 推送参数，需要将pushmethod指定为wxpusher，应用和uid的免费申请参考:https://wxpusher.zjiecode.com/

--- a/main.py
+++ b/main.py
@@ -155,7 +155,7 @@ class Task(object):
             response = requests.post(url, data=data, headers = {'Content-type': 'application/x-www-form-urlencoded'})
             errno = response.json()['data']['errno']
         else:                                           #Server酱 普通版
-            url = 'https://sc.ftqq.com/' + self.sckey + '.send'
+            url = 'http://sc.ftqq.com/' + self.sckey + '.send'
             response = requests.post(url, data=data, headers = {'Content-type': 'application/x-www-form-urlencoded'})
             errno = response.json()['errno']
         if errno == 0:

--- a/main.py
+++ b/main.py
@@ -32,12 +32,14 @@ class Task(object):
     '''
     对象的构造函数
     '''
-    def __init__(self, uin, pwd, sckey, countrycode=86):
+    def __init__(self, uin, pwd, pushmethod, sckey, appToken, wxpusheruid, countrycode=86):
         self.uin = uin
         self.pwd = pwd
         self.countrycode = countrycode
+        self.pushmethod = pushmethod
         self.sckey = sckey
-
+        self.appToken = appToken
+        self.wxpusheruid = wxpusheruid
     '''
     带上用户的cookie去发送数据
     url:完整的URL路径
@@ -103,6 +105,39 @@ class Task(object):
         self.listenSongs = data['listenSongs']
         self.log('获取用户详情成功')
         logging.info('获取用户详情成功')
+
+
+    '''
+    Wxpusher推送
+    '''
+    def wxpusher(self):
+        if (self.appToken == '' or self.wxpusheruid == ''):
+            logger.info('未填写WxPusher推送所需参数，请检查')
+            return
+        self.diyText() # 构造发送内容
+        url = 'http://wxpusher.zjiecode.com/api/send/message/'
+        data = json.dumps({
+            "appToken":self.appToken,
+            "content":self.content,
+            "summary":self.title,
+            "contentType":3,
+            "uids":[self.wxpusheruid]
+        })
+        response = requests.post(url, data = data, headers = {'Content-Type': 'application/json;charset=UTF-8'})
+        r=response.json()
+        if r['data'][0]['status'] == '创建发送任务成功':
+            self.log('用户:' + self.name + '  WxPusher推送成功')
+            logging.info('用户:' + self.name + '  WxPusher推送成功')
+        else:
+            self.log('用户:' + self.name + '  WxPusher推送失败,请检查appToken和uid是否正确')
+            logging.info('用户:' + self.name + '  WxPusher推送失败,请检查appToken和uid是否正确')
+
+    '''
+    自定义要推送到微信的内容
+    title:消息的标题
+    content:消息的内容,支持MarkDown格式
+    contentType:消息类型,1为普通文本,2为html,3为markdown
+    '''
 
     '''
     Server推送
@@ -205,7 +240,10 @@ class Task(object):
             self.list.append("- 打卡结束\n\n")
             self.list.append("- 消息推送\n\n")
             self.dakaSongs_list = ''.join(self.list)
-            self.server()
+            if self.pushmethod == 'wxpusher':
+                self.wxpusher()
+            else:
+                self.server()
         except:
             self.log('用户任务执行中断,请检查账号密码是否正确')
             logging.error('用户任务执行中断,请检查账号密码是否正确========================================')
@@ -228,7 +266,10 @@ def init():
     api = config['setting']['api']
     md5Switch = config.getboolean('setting','md5Switch')
     peopleSwitch = config.getboolean('setting','peopleSwitch')
+    pushmethod = config['setting']['pushmethod']
     sckey = config['setting']['sckey']
+    appToken = config['setting']['appToken']
+    wxpusheruid = config['setting']['wxpusheruid']
     print('配置文件读取完毕')
     logging.info('配置文件读取完毕')
     conf = {
@@ -238,7 +279,10 @@ def init():
             'api': api,
             'md5Switch': md5Switch, 
             'peopleSwitch':peopleSwitch,
-            'sckey':sckey
+            'pushmethod':pushmethod,
+            'sckey':sckey,
+            'appToken':appToken,
+            'wxpusheruid':wxpusheruid
         }
     return conf
 
@@ -288,7 +332,7 @@ def taskPool():
         for man in account:
             print('账号: ' + man['account'] + '  开始执行')
             logging.info('账号: ' + man['account'] + '  开始执行========================================')
-            task = Task(man['account'], man['password'], man['sckey'])
+            task = Task(man['account'], man['password'], man['pushmethod'],man['sckey'], man['appToken'], man['wxpusheruid'])
             task.start()
             time.sleep(10)
         print('所有账号已全部完成任务,服务进入休眠中,等待明天重新启动')
@@ -300,7 +344,7 @@ def taskPool():
             print('MD5开关已打开,即将开始为你加密,密码不会上传至服务器,请知悉')
             logging.info('MD5开关已打开,即将开始为你加密,密码不会上传至服务器,请知悉')
             config['pwd'] = md5(config['pwd'])
-        task = Task(config['uin'], config['pwd'], config['sckey'], config['countrycode'])
+        task = Task(config['uin'], config['pwd'], config['pushmethod'], config['sckey'], config['appToken'], config['wxpusheruid'], config['countrycode'])
         task.start()
 
 '''


### PR DESCRIPTION
最近腾讯云函数部署可能出现Server酱推送错误，主要有两个原因：
1、Server酱目前限制单ip请求次数，超出后会无法推送，报609错误。
见[官方说明](http://sc.ftqq.com/3.version)
[![y2zPBV.png](https://s3.ax1x.com/2021/02/17/y2zPBV.png)](https://imgchr.com/i/y2zPBV)

2、Server酱最近经常发生超出HTTPS配额的情况，导致无法推送。
见官方说明：[关于最近 Server酱 609/慢/超出网站配额 的说明](https://weibo.com/1088413295/JDqyatOic?from=page_1005051088413295_profile&wvr=6&mod=weibotime)
[![y2z84e.png](https://s3.ax1x.com/2021/02/17/y2z84e.png)](https://imgchr.com/i/y2z84e)

#87 #89 

针对上述问题，进行如下修改：
1、增加通过[WxPusher服务](https://wxpusher.zjiecode.com/)进行推送；
2、增加通过[Server酱Turbo捐赠版](https://sct.ftqq.com/)进行推送；
3、修改Server酱免费版推送为通过 HTTP 发送 POST。